### PR TITLE
Fix bug in buildIsTrue

### DIFF
--- a/src/buildwasmff_utils.js
+++ b/src/buildwasmff_utils.js
@@ -175,7 +175,7 @@ module.exports = function buildUtils(ctx) {
                 c.ret(
                     c.i32_eqz(
                         c.call(
-                            ctx.prefixF + "_isZero",
+                            ctx.prefixI + "_isZero",
                             c.i32_add(
                                 c.getLocal("px"),
                                 c.i32_const(8)


### PR DESCRIPTION
The generated code was using ctx.prefixF + "_isZero". This creates a call to $Fr_F1m_isZero, which doesn't exist. The fix uses ctx.prefixF + "_isZero", which creates a call to $Fr_Int_isZero instead.